### PR TITLE
feat: Remove quiz functionality in InstructureController

### DIFF
--- a/controllers/InstructureController.js
+++ b/controllers/InstructureController.js
@@ -437,6 +437,57 @@ const editQuiz = async (request, h) => {
 };
 
 /**
+ * 
+ * @param {Request} request 
+ * @param {ResponseToolkit} h 
+ */
+const removeQuiz = async (request, h) => {
+  try {
+    const { credentials } = request.auth;
+    if (credentials.role !== 2)
+      return h
+        .response({
+          message: "Forbidden",
+        })
+        .code(403);
+    
+    const Quiz = new QuizModel();
+    const { id } = request.params;
+    if (!id)
+      return h
+        .response({
+          message: "Invalid payload",
+        })
+        .code(400);
+    
+    const quiz = await Quiz.db.findUnique({
+      where: {
+        id,
+      },
+    });
+
+    if (!quiz)
+      return h
+        .response({
+          message: "Quiz not found",
+        })
+        .code(404);
+    
+    await Quiz.db.delete({
+      where: {
+        id,
+      },
+    });
+
+    return h.response({
+      message: "Success",
+    });
+  } catch (err) {
+    console.error(err);
+  }
+};
+
+/**
  *
  * @param {Request} request
  * @param {ResponseToolkit} h
@@ -883,6 +934,7 @@ module.exports = {
   removeCategory,
   createQuiz,
   editQuiz,
+  removeQuiz,
   allQuiz,
   quizDetail,
   getAllQuestion,

--- a/routes/api/instructure.js
+++ b/routes/api/instructure.js
@@ -21,6 +21,7 @@ const {
   getOption,
   removeOption,
   getAllOptions,
+  removeQuiz,
 } = require("../../controllers/InstructureController");
 
 /**
@@ -106,6 +107,14 @@ module.exports = [
       auth: "jwt",
     },
     handler: quizDetail,
+  },
+  {
+    method: "GET",
+    path: "/api/instructure/quiz/{id}",
+    config: {
+      auth: "jwt",
+    },
+    handler: removeQuiz,
   },
   {
     method: "GET",


### PR DESCRIPTION
This commit adds the `removeQuiz` function to the `InstructureController.js` file. The function allows the removal of a quiz based on the provided quiz ID. It checks the user's role and returns a forbidden response if the user is not authorized. If the quiz is not found, a not found response is returned. Otherwise, the quiz is deleted from the database and a success response is returned. This addition enhances the functionality of the application by allowing the removal of quizzes.

Code changes:
- Add `removeQuiz` function to `InstructureController.js`
- Implement logic to remove a quiz from the database