### PR TITLE
refactor: Update `is_correct` handling in Option model and controller

### DIFF
--- a/prisma/dbml/schema.dbml
+++ b/prisma/dbml/schema.dbml
@@ -63,7 +63,7 @@ Table Question {
 Table Option {
   id String [pk]
   option String [not null]
-  is_correct Boolean [not null]
+  is_correct Boolean [not null, default: false]
   question_id String [not null]
   created_at DateTime [default: `now()`, not null]
   updated_at DateTime [not null]

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -78,7 +78,7 @@ model Question {
 model Option {
   id          String       @id @default(uuid())
   option      String
-  is_correct  Boolean
+  is_correct  Boolean      @default(false)
   question_id String
   created_at  DateTime     @default(now())
   updated_at  DateTime     @updatedAt


### PR DESCRIPTION
This commit updates the `is_correct` handling in the Option model and controller. In the `schema.dbml` file, the `is_correct` column is modified to have a default value of `false`. Similarly, in the `schema.prisma` file, the `is_correct` field is updated to have a default value of `false`. Additionally, the `createOption` and `editOption` functions in the `InstructureController.js` file are refactored to remove the `is_correct` parameter and property update. Instead, the `editOption` function now updates all other options for the same question to set their `is_correct` property to `false`. These changes improve the clarity and consistency of option management in the application.

Code changes:
- Modify `is_correct` column in `schema.dbml` to have a default value of `false`
- Update `is_correct` field in `schema.prisma` to have a default value of `false`
- Refactor `createOption` function in `InstructureController.js` to remove `is_correct` parameter
- Refactor `editOption` function in `InstructureController.js` to remove `is_correct` property update and update other options to set `is_correct` to `false`