### PR TITLE
refactor: Update image handling in InstructureController

### DIFF
--- a/controllers/InstructureController.js
+++ b/controllers/InstructureController.js
@@ -259,7 +259,6 @@ const createQuiz = async (request, h) => {
         .code(400);
 
     // save image
-    const mime = image.split(";")[0].split(":")[1];
     const buffer = Buffer.from(
       image.replace(/^data:image\/\w+;base64,/, ""),
       "base64"
@@ -427,8 +426,14 @@ const editQuiz = async (request, h) => {
         .code(400);
 
     if (image) {
-      const buffer = Buffer.from(image, "base64");
-      fs.writeFileSync(`uploads/${now}.png`, buffer);
+      const buffer = Buffer.from(
+        image.replace(/^data:image\/\w+;base64,/, ""),
+        "base64"
+      );
+
+      const sharpImage = await sharp(buffer).toFormat("png").toBuffer();
+
+      fs.writeFileSync(`uploads/${now}.png`, sharpImage);
     }
 
     const quizData = await Quiz.db.update({


### PR DESCRIPTION
This commit refactors the image handling in the InstructureController.js file. The code is updated to use the sharp library for image processing. The previous code that saved the image as a base64 string is replaced with code that converts the image to a buffer, formats it as PNG, and then saves it to the uploads directory. This change improves the efficiency and performance of image handling in the application.

Code changes:
- Replace base64 image saving with sharp library for image processing
- Convert image to buffer, format as PNG, and save to uploads directory