### PR TITLE
feat: Add category field to quizDetail query in UserController

### DIFF
--- a/controllers/UserController.js
+++ b/controllers/UserController.js
@@ -115,6 +115,7 @@ const quizDetail = async (request, h) => {
             name: true,
           },
         },
+        category: true,
         session: {
           select: {
             id: true,
@@ -124,6 +125,11 @@ const quizDetail = async (request, h) => {
                 name: true,
               },
             },
+          },
+        },
+        _count: {
+          select: {
+            questions: true,
           },
         },
       },


### PR DESCRIPTION
This commit adds the `category` field to the `quizDetail` query in the `UserController.js` file. The `category` field is set to `true` in the Prisma select statement, allowing the associated category information to be included in the response. This change enhances the functionality of the application by providing the category information along with the quiz details.

Code changes:
- Add `category` field to the `quizDetail` query in `UserController.js`