### PR TITLE
feat: Add API documentation link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ CDN_URL="http://localhost:3000"
 5. Run `npm run dev` to start the server
 
 ## API Documentation
-Using Hoppscotch to test the API
+[Click here](https://docs.quizlogy.xyz)


### PR DESCRIPTION
This commit adds a link to the API documentation in the README.md file. The link directs users to the documentation page hosted at [https://docs.quizlogy.xyz](https://docs.quizlogy.xyz). This addition improves the accessibility and usability of the application by providing easy access to the API documentation.

Code changes:
- Update the README.md file to include the API documentation link